### PR TITLE
chore: support php attributes to define PrestashopTrait fields

### DIFF
--- a/src/Entity/PrestashopTrait.php
+++ b/src/Entity/PrestashopTrait.php
@@ -11,16 +11,19 @@ trait PrestashopTrait
     /**
      * @ORM\Column(name="prestashop_id", type="integer", nullable=true)
      */
+    #[ORM\Column(name: "prestashop_id", type: "integer", nullable: true)]
     protected ?int $prestashopId = null;
 
     /**
      * @ORM\Column(name="prestashop_created_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: "prestashop_created_at", type: "datetime", nullable: true)]
     protected ?DateTime $prestashopCreatedAt;
 
     /**
      * @ORM\Column(name="prestashop_updated_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: "prestashop_updated_at", type: "datetime", nullable: true)]
     protected ?DateTime $prestashopUpdatedAt;
 
     public function getPrestashopId(): ?int


### PR DESCRIPTION
Not a big one, just by default, Sylius is settings doctrine mapping: attribute instead annotation.