### PR TITLE
feat(locale): use existing locale with same code

### DIFF
--- a/src/Provider/Locale/LocaleResourceProvider.php
+++ b/src/Provider/Locale/LocaleResourceProvider.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Jgrasp\PrestashopMigrationPlugin\Provider\Locale;
+
+use ReflectionClass;
+
+use Jgrasp\PrestashopMigrationPlugin\Attribute\PropertyAttributeAccessor;
+use Jgrasp\PrestashopMigrationPlugin\Model\ModelInterface;
+use Jgrasp\PrestashopMigrationPlugin\Provider\ResourceProviderInterface;
+use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+class LocaleResourceProvider implements ResourceProviderInterface
+{
+    private RepositoryInterface $repository;
+    
+    private ResourceProviderInterface $provider;
+
+    private PropertyAttributeAccessor $propertyAttributeAccessor;
+
+    public function __construct(ResourceProviderInterface $provider, RepositoryInterface $repository, PropertyAttributeAccessor $propertyAttributeAccessor)
+    {
+        $this->provider = $provider;
+        $this->repository = $repository;
+        $this->propertyAttributeAccessor = $propertyAttributeAccessor;
+    }
+
+    public function getResource(ModelInterface $model): ResourceInterface
+    {
+        $modelReflection = new ReflectionClass($model);
+        $modelProperties = $modelReflection->getProperties();
+        $localeCode      = null;
+
+        foreach ($modelProperties as $property) {
+            if ($property->getName() === 'code') {
+                $localeCode = $property->getValue($model);
+            }
+        }
+
+        if (!empty($localeCode)) {
+            $resource = $this->repository->findOneBy(['code' => StringInflector::nameToCode($localeCode)]);
+        }
+
+        if (empty($resource)) {
+            $resource = $this->provider->getResource($model);
+        }
+
+        return $resource;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -207,6 +207,14 @@
             <argument type="service" id="sylius.factory.product"/>
         </service>
 
+        <!--RESOURCE PROVIDER -->
+        <service id="Jgrasp\PrestashopMigrationPlugin\Provider\Locale\LocaleResourceProvider"
+                 decorates="prestashop.provider.locale">
+            <argument type="service" id=".inner"/>
+            <argument type="service" id="sylius.repository.locale"/>
+            <argument type="service" id="Jgrasp\PrestashopMigrationPlugin\Attribute\PropertyAttributeAccessor"/>
+        </service>
+
         <!-- REPOSITORY -->
         <service id="prestashop.repository.configuration"
                  alias="Jgrasp\PrestashopMigrationPlugin\Repository\Configuration\ConfigurationRepository"/>


### PR DESCRIPTION
When importing locale, if a local with same lang code exist, let's reuse it!

Not sure if this is the right way to achieve it, its worked for me.

<img width="994" alt="Capture d’écran, le 2024-10-12 à 19 32 26" src="https://github.com/user-attachments/assets/49cef050-e03f-4b65-adde-e3a3a1d834d6">

<img width="995" alt="Capture d’écran, le 2024-10-12 à 19 32 37" src="https://github.com/user-attachments/assets/a867381d-8571-4e12-bcfb-02aa0e4c6847">

<img width="989" alt="Capture d’écran, le 2024-10-12 à 19 32 57" src="https://github.com/user-attachments/assets/98906d30-63e8-4eb8-bb35-ffabe50ab3b6">
